### PR TITLE
fix default parameter syntax error

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -25,8 +25,11 @@ class Cache
      * @param App    $app
      * @param string $cacheDirectory
      */
-    public function __construct(App $app, $cacheDirectory = __DIR__ . '/../cache/')
+    public function __construct(App $app, $cacheDirectory = null)
     {
+        if(is_null($cacheDirectory)) {
+            $cacheDirectory = __DIR__ . '/../cache/';
+        }
         $this->directory = $cacheDirectory;
         $this->fileHandler = new FileHandler($cacheDirectory);
         $this->app = $app;


### PR DESCRIPTION
fix error:
```
Parse error: syntax error, unexpected '.', expecting ')' in /home/xxx/www/run/vendor/snicholson/slimfilecache/src/Cache.php on line 28
```